### PR TITLE
- Added installer, limited requirements.txt package versions, fixed ideal.json

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# install.sh
+# Written by Kevin Cole <kevin.cole@novawebcoop.org> 2017.04.02
+#
+# This determines if we're in a Python virtual environment, and,
+# if so, fetches and installs all the prerequisites.
+#
+# Note: This installer was designed with and for Mac OS X 10.12.4
+# (Sierra).  py2app in particular, is used to "bundle" the python code
+# into Mac apps and "brand" them with an icon I designed.
+#
+
+if [ -z ${VIRTUAL_ENV} ]
+then
+  echo "You must run this from a Python virtual environment."
+  echo "(Read up on virtualenv for more info.)"
+else
+  pip install -U pip
+  pip install -r requirements.txt
+  $VIRTUAL_ENV/bin/pyside_postinstall.py -install
+  cd src
+  rm -rf build dist
+  py2applet --make-setup makeconf.py
+  python setup.py py2app -A
+  rm setup.py
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-future
-PySide
+future >= 0.16.0
+PySide == 1.2.2
+py2app >= 0.10

--- a/src/ideal.json
+++ b/src/ideal.json
@@ -24,8 +24,8 @@
       "program" : 1,
       "targets" : [3],
       "step" : 2,
-      "range" [-5, 5],
-      "rsize" : [200, 250]
+      "range" : [-5, 5],
+      "rsize" : [200, 250],
       "noise" : [
         {
           "sample" : 1,


### PR DESCRIPTION
I'm running Mac OS X 10.12.4 ("Sierra") and have found that PySide works best when held back a bit. So, I'm limiting it to 1.2.2. The current is 1.2.4.  The installer generates a makeconf.app directory.

And I found two typos in ideal.json when I tried to load it in Python. Now fixed.