### PR TITLE
- Prevent Bash from interpreting Python scripts as Bash scripts in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,10 +18,10 @@ then
 else
   pip install -U pip
   pip install -r requirements.txt
-  $VIRTUAL_ENV/bin/pyside_postinstall.py -install
+  python2.7 $VIRTUAL_ENV/bin/pyside_postinstall.py -install
   cd src
   rm -rf build dist
   py2applet --make-setup makeconf.py
-  python setup.py py2app -A
+  python2.7 setup.py py2app -A
   rm setup.py
 fi


### PR DESCRIPTION
Explicit is better than implicit. ;-) I found this out when it tried to run pyside_postinstall.py as a Bash script and managed to successfully create two files with carriage returns in the filename "re^M" and "stat^M". Oops.