### PR TITLE
Overwriting prevention, and unedited loudspeakers now Red

### DIFF
--- a/src/presets.py
+++ b/src/presets.py
@@ -119,7 +119,7 @@ class FancyCircle(LocalizationPane.ControlPane):
         for i in range(8):
             for button in ('louder', 'softer'):
                 self.speakers[i][button].hide()
-            self.speakers[i]['select'].setStyleSheet(self.style.format('black'))
+            self.speakers[i]['select'].setStyleSheet(self.style.format('red'))
         shared.logger.debug("finishing fancy circle")
 
     def paintEvent(self, event):

--- a/src/shared.py
+++ b/src/shared.py
@@ -8,6 +8,7 @@ import PySide.QtCore
 from builtins import super
 
 import os
+import re
 import json
 import logging
 
@@ -130,10 +131,27 @@ class MainWidget(PySide.QtGui.QGroupBox):
         if not os.path.exists(savedir):
             os.mkdir(savedir)
 
-        self.filename = QFileDialog.getExistingDirectory(self,
-                                                         caption="Export Config File",
-                                                         dir=savedir,
-                                                         )
+        pattern = re.compile(savedir + ".+")  # At least one character beyond
+        attempted = False
+        self.filename = ""
+
+        while not pattern.match(self.filename):
+            self.filename = QFileDialog.getExistingDirectory(self,
+                                                             caption="Export Config File",
+                                                             dir=savedir,
+                                                             )
+            attempted = True
+            if attempted and not pattern.match(self.filename):
+                message  = """<p>Directory choice not allowed.</p>"""
+                message += """<p>Try again.</p>"""
+                box = PySide.QtGui.QMessageBox()
+                box.setIcon(PySide.QtGui.QMessageBox.Warning)
+                box.setWindowTitle("Invalid directory")
+                box.setText("<strong>Invalid directory</strong>")
+                box.setInformativeText(message.replace(" ", "&nbsp;"))
+                box.setStandardButtons(PySide.QtGui.QMessageBox.Ok)
+                box.exec_()
+
         print self.filename
         if not self.filename:
             return

--- a/src/shared.py
+++ b/src/shared.py
@@ -178,7 +178,7 @@ class MainWidget(PySide.QtGui.QGroupBox):
             box.setWindowTitle("Directory not empty")
             box.setText("<strong>Directory not empty</strong>")
             box.setInformativeText("""The directory {} is not empty. continue?
-                    This will wipe out everything""".format(path))
+                    This will wipe out everything""".format(str(path)))
             box.setStandardButtons(PySide.QtGui.QMessageBox.Save |
                     PySide.QtGui.QMessageBox.Cancel)
             box.setDefaultButton(PySide.QtGui.QMessageBox.Cancel)
@@ -191,11 +191,11 @@ class MainWidget(PySide.QtGui.QGroupBox):
                     return self.export_data()
             oldstuff = tempfile.mkdtemp(suffix="ConfigMaker", prefix='{}-'.format(path.name))
             os.rmdir(oldstuff) # To be copied to later
-            shutil.move(path, oldstuff)
+            shutil.move(str(path), oldstuff)
             # Oh also dont mess up this section cuz right here all the user's
             # contents are in ram in both places
             logger.info('Moving old contents to %s', oldstuff)
-            os.mkdir(path)
+            os.mkdir(str(path))
 
         # NOTE: if users start opening up multiple windows, implement a lock
         # file
@@ -208,5 +208,5 @@ class MainWidget(PySide.QtGui.QGroupBox):
 
         self.parent.setWindowTitle(self.parent.windowtitle.format(path.name))
 
-        with open('{}/00-index.json'.format(path), 'w') as outfile:
+        with open('{}/00-index.json'.format(str(path)), 'w') as outfile:
             outfile.write(json.dumps(self.savedcontents, **pretty_print))


### PR DESCRIPTION
Dragana couldn't see enough contrast between the black button vs. the green, and asked for the black to become red.

Also, all presets and ratings must be within ~/.config/sound-advice/presets/ and ~/.config/sound-advice/ratings/ respectively. This is now enforced.

And the pathlib vs. shutil (PosixPaths vs. strings) issue is also taken care of.